### PR TITLE
fix: change signaling server url back to deployment signal server

### DIFF
--- a/pass_go/Pass_Go/static/js/video-chat.js
+++ b/pass_go/Pass_Go/static/js/video-chat.js
@@ -1,6 +1,6 @@
 // Config variables: change them to point to your own servers
-// const SIGNALING_SERVER_URL = 'https://rtc.pass-go.net/signaler';
-const SIGNALING_SERVER_URL = 'localhost:8000/signaler';
+// const SIGNALING_SERVER_URL = 'localhost:8000/signaler';
+const SIGNALING_SERVER_URL = 'https://rtc.pass-go.net/signaler';
 const TURN_SERVER_URL = 'rtc.pass-go.net:3478';
 const TURN_SERVER_USERNAME = 'username';
 const TURN_SERVER_CREDENTIAL = 'credential';


### PR DESCRIPTION
I forgot to change the signaling server url back from the url I was using for local testing.